### PR TITLE
Set PGPASSWORD in posters user env

### DIFF
--- a/madlib_setup.sh
+++ b/madlib_setup.sh
@@ -5,8 +5,8 @@ export USER=madlib
 export DBMS=postgres
 export PGPASSWORD=password
 
-su --login - postgres --command "/usr/local/madlib/bin/madpack -p $DBMS -c $USER@$HOST/$DATABASE install"
+su --login - postgres --command "PGPASSWORD=${PGPASSWORD} /usr/local/madlib/bin/madpack -p $DBMS -c $USER@$HOST/$DATABASE install"
 
 if [ $? -eq 0 ]; then
-	su --login - postgres --command "/usr/local/madlib/bin/madpack -p $DBMS -c $USER@$HOST/$DATABASE install-check"
+	su --login - postgres --command "PGPASSWORD=${PGPASSWORD} /usr/local/madlib/bin/madpack -p $DBMS -c $USER@$HOST/$DATABASE install-check"
 fi


### PR DESCRIPTION
Fix for issue #1.

In order to install madlib non interactively via the madpack script,
the PGPASSWORD variable should be set in the postgres user environment.
